### PR TITLE
Refactor `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::{
     env, io,
     path::{Path, PathBuf},
     process::Command,
+    slice,
 };
 
 #[path = "build/homeworks.rs"]
@@ -33,6 +34,10 @@ fn main() -> io::Result<()> {
 fn build_syllabus(manifest_dir: &Path) -> io::Result<()> {
     let source = manifest_dir.join("src/syllabus.typ");
     let output = manifest_dir.join("public/syllabus.pdf");
+
+    if utils::generated_files_are_current(slice::from_ref(&source), &[&output]) {
+        return Ok(());
+    }
 
     let mut command = Command::new("typst");
     command.arg("compile").arg(&source).arg(&output);

--- a/build.rs
+++ b/build.rs
@@ -1,246 +1,50 @@
-use ignore::Walk;
-use rayon::prelude::*;
 use std::{
-    fs::{self, File},
-    io::{self, Write},
+    env, io,
     path::{Path, PathBuf},
     process::Command,
 };
-use zip::{ZipWriter, write::SimpleFileOptions};
 
-const LECTURES: &[(&str, &str)] = &[
-    ("01_introduction", "introduction"),
-    ("02_ownership_p1", "ownership_p1"),
-    ("03_structs_enums", "structs_enums"),
-    ("04_collections_generics", "collections_generics"),
-    ("05_errors_traits", "errors_traits"),
-    ("06_modules_testing", "modules_testing"),
-    ("07_ecosystem", "ecosystem"),
-    ("08_closures_iterators", "closures_iterators"),
-    ("09_ownership_p2", "ownership_p2"),
-    ("10_lifetimes", "lifetimes"),
-    ("11_smart_pointers", "smart_pointers"),
-    ("12_unsafe", "unsafe"),
-    ("13_parallelism", "parallelism"),
-    ("14_concurrency", "concurrency"),
-];
+#[path = "build/homeworks.rs"]
+mod homeworks;
+#[path = "build/lectures.rs"]
+mod lectures;
+#[path = "build/utils.rs"]
+mod utils;
 
-const HOMEWORKS: &[(&str, &str)] = &[
-    ("homeworks/week1/primerlab", "primerlab"),
-    ("homeworks/week2/getownedlab", "getownedlab"),
-    ("homeworks/week3/cardlab", "cardlab"),
-    ("homeworks/week4/multilab", "multilab"),
-    ("homeworks/week5/pokerlab", "pokerlab"),
-    ("homeworks/week5-ec/summarylab", "summarylab"),
-    ("homeworks/week6/greplab", "greplab"),
-    ("homeworks/week8/iterlab", "iterlab"),
-    ("homeworks/week10/splitlab", "splitlab"),
-    ("homeworks/week11/filterlab", "filterlab"),
-    ("homeworks/week13/rowlab", "rowlab"),
-];
+fn main() -> io::Result<()> {
+    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .ok_or_else(|| io::Error::other("CARGO_MANIFEST_DIR is not set"))?;
 
-fn watch_lectures() {
-    for entry in Walk::new("lectures").flatten() {
-        if entry.path().is_file() {
-            println!("cargo:rerun-if-changed={}", entry.path().display());
-        }
-    }
-}
-
-fn needs_rebuild(src: &Path, outputs: &[&Path]) -> bool {
-    let Ok(src_meta) = fs::metadata(src) else {
-        return true;
-    };
-    let Ok(src_mtime) = src_meta.modified() else {
-        return true;
-    };
-
-    for output in outputs {
-        match fs::metadata(output) {
-            Ok(meta) => {
-                if meta.modified().map(|t| t < src_mtime).unwrap_or(true) {
-                    return true;
-                }
-            }
-            Err(_) => return true,
-        }
-    }
-    false
-}
-
-fn build_lectures() {
-    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    let lectures_dir = manifest_dir.join("lectures");
-    let out_dir = manifest_dir.join("public/lectures");
-
-    LECTURES.par_iter().for_each(|(dir_name, topic)| {
-        let src_dir = lectures_dir.join(dir_name);
-        let md_file = src_dir.join(format!("{topic}.md"));
-
-        if !md_file.exists() {
-            println!("cargo:warning=Lecture not found: {}", md_file.display());
-            return;
-        }
-
-        let topic_out_dir = out_dir.join(dir_name);
-        fs::create_dir_all(&topic_out_dir).ok();
-
-        let dark_pdf = topic_out_dir.join(format!("{topic}-dark.pdf"));
-        let light_pdf = topic_out_dir.join(format!("{topic}-light.pdf"));
-
-        // Skip if up to date
-        if !needs_rebuild(&md_file, &[&dark_pdf, &light_pdf]) {
-            return;
-        }
-
-        let config = lectures_dir.join("marp_config.json");
-
-        // Render dark theme
-        render_marp(&md_file, &dark_pdf, &config, &src_dir);
-
-        // Render light theme
-        let content = fs::read_to_string(&md_file).expect("Failed to read markdown");
-        let light_content = content.replace("class: invert", "# class: invert");
-        let temp_light = src_dir.join(format!("{topic}-light-temp.md"));
-        fs::write(&temp_light, &light_content).expect("Failed to write temp file");
-
-        render_marp(&temp_light, &light_pdf, &config, &src_dir);
-        fs::remove_file(&temp_light).ok();
-
-        println!("cargo:warning=Rendered {topic}");
-    });
-}
-
-fn render_marp(input: &Path, output: &Path, config: &Path, working_dir: &Path) {
-    let status = Command::new("marp")
-        .arg(input.file_name().unwrap())
-        .arg("-c")
-        .arg(config)
-        .arg("-o")
-        .arg(output)
-        .current_dir(working_dir)
-        .status();
-
-    match status {
-        Ok(s) if s.success() => {}
-        Ok(s) => println!("cargo:warning=marp exited with: {:?}", s),
-        Err(e) => println!(
-            "cargo:warning=Failed to run marp: {e} (kind: {:?})",
-            e.kind()
-        ),
-    }
-}
-
-fn watch_homeworks() {
-    for entry in Walk::new("homeworks").flatten() {
-        let path = entry.path();
-        if path.is_file() {
-            println!("cargo:rerun-if-changed={}", path.display());
-        }
-    }
-}
-
-fn build_homeworks() {
-    HOMEWORKS.par_iter().for_each(|(path, slug)| {
-        if Path::new(path).exists() {
-            let out_dir = format!("public/hw/{slug}");
-            fs::create_dir_all(&out_dir).ok();
-
-            // Create zip handout
-            let zip_path = format!("{out_dir}/{slug}.zip");
-            if let Err(e) = create_zip(path, &zip_path, slug) {
-                println!("cargo:warning=Failed to zip {slug}: {e}");
-            }
-
-            // Generate docs
-            let manifest = format!("{path}/Cargo.toml");
-            let status = Command::new("cargo")
-                .args([
-                    "doc",
-                    "--no-deps",
-                    "--manifest-path",
-                    &manifest,
-                    "--target-dir",
-                    &out_dir,
-                ])
-                .status();
-
-            match status {
-                Ok(s) if s.success() => {}
-                Ok(_) => println!("cargo:warning=cargo doc failed for {slug}"),
-                Err(e) => println!("cargo:warning=Failed to run cargo doc for {slug}: {e}"),
-            }
-        }
-    });
-}
-
-fn build_syllabus() {
-    let status = Command::new("typst")
-        .args(["compile", "src/syllabus.typ", "public/syllabus.pdf"])
-        .status()
-        .expect("failed to run typst");
-
-    if !status.success() {
-        panic!("typst compilation failed");
-    }
-}
-
-fn main() {
     println!("cargo:rerun-if-changed=src/syllabus.typ");
 
-    // We can't just use "cargo:rerun-if-changed=homeworks" because we'd be
-    // recursively rebuilding over and over due to Cargo.lock and handin.zip
-    watch_homeworks();
-    watch_lectures();
+    // Watching individual files avoids rebuild loops from ignored homework artifacts.
+    emit_rerun_directives(&manifest_dir.join("homeworks"))?;
+    emit_rerun_directives(&manifest_dir.join("lectures"))?;
 
-    // Create public dir if it doesn't exist
-    std::fs::create_dir_all("public").ok();
+    utils::create_directory(&manifest_dir.join("public"))?;
 
-    // Build everything in parallel
-    rayon::join(
-        || rayon::join(build_syllabus, build_lectures),
-        build_homeworks,
-    );
+    // Run stages sequentially so a failure prevents later work from starting.
+    build_syllabus(&manifest_dir)?;
+    lectures::build(&manifest_dir)?;
+    homeworks::build(&manifest_dir)
 }
 
-fn create_zip(src_dir: &str, zip_path: &str, root_name: &str) -> io::Result<()> {
-    let file = File::create(zip_path)?;
-    let mut zip = ZipWriter::new(file);
-    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+fn build_syllabus(manifest_dir: &Path) -> io::Result<()> {
+    let source = manifest_dir.join("src/syllabus.typ");
+    let output = manifest_dir.join("public/syllabus.pdf");
 
-    let src_path = Path::new(src_dir);
-    add_dir_to_zip(&mut zip, src_path, root_name, &options)?;
+    let mut command = Command::new("typst");
+    command.arg("compile").arg(&source).arg(&output);
+    utils::run_command(command)?;
 
-    zip.finish()?;
-    Ok(())
+    utils::require_nonempty_file(&output)
 }
 
-fn add_dir_to_zip(
-    zip: &mut ZipWriter<File>,
-    dir: &Path,
-    prefix: &str,
-    options: &SimpleFileOptions,
-) -> io::Result<()> {
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let name = path.file_name().unwrap().to_string_lossy();
-
-        // Skip target directory and hidden files
-        if name == "target" || name.starts_with('.') {
-            continue;
-        }
-
-        let zip_path = format!("{prefix}/{name}");
-
-        if path.is_dir() {
-            zip.add_directory(&zip_path, *options)?;
-            add_dir_to_zip(zip, &path, &zip_path, options)?;
-        } else {
-            zip.start_file(&zip_path, *options)?;
-            let contents = fs::read(&path)?;
-            zip.write_all(&contents)?;
-        }
+fn emit_rerun_directives(root: &Path) -> io::Result<()> {
+    for path in utils::files_in_tree(root)? {
+        println!("cargo:rerun-if-changed={}", path.display());
     }
+
     Ok(())
 }

--- a/build/homeworks.rs
+++ b/build/homeworks.rs
@@ -1,0 +1,94 @@
+use crate::utils;
+use rayon::prelude::*;
+use std::{fs::File, io, path::Path, process::Command};
+use zip::{ZipWriter, write::SimpleFileOptions};
+
+struct Homework {
+    source: &'static str,
+    slug: &'static str,
+}
+
+impl Homework {
+    const fn new(source: &'static str, slug: &'static str) -> Self {
+        Self { source, slug }
+    }
+}
+
+const HOMEWORKS: &[Homework] = &[
+    Homework::new("homeworks/week1/primerlab", "primerlab"),
+    Homework::new("homeworks/week2/getownedlab", "getownedlab"),
+    Homework::new("homeworks/week3/cardlab", "cardlab"),
+    Homework::new("homeworks/week4/multilab", "multilab"),
+    Homework::new("homeworks/week5/pokerlab", "pokerlab"),
+    Homework::new("homeworks/week5-ec/summarylab", "summarylab"),
+    Homework::new("homeworks/week6/greplab", "greplab"),
+    Homework::new("homeworks/week8/iterlab", "iterlab"),
+    Homework::new("homeworks/week10/splitlab", "splitlab"),
+    Homework::new("homeworks/week11/filterlab", "filterlab"),
+    Homework::new("homeworks/week13/rowlab", "rowlab"),
+];
+
+pub fn build(manifest_dir: &Path) -> io::Result<()> {
+    HOMEWORKS
+        .par_iter()
+        .try_for_each(|homework| build_homework(homework, manifest_dir))
+}
+
+fn build_homework(homework: &Homework, manifest_dir: &Path) -> io::Result<()> {
+    let source = manifest_dir.join(homework.source);
+    let output_dir = manifest_dir.join("public/hw").join(homework.slug);
+
+    utils::require_directory(&source)?;
+    utils::create_directory(&output_dir)?;
+
+    let manifest = source.join("Cargo.toml");
+    let mut command = Command::new("cargo");
+    command
+        // Dioxus sets WASM-specific Rust flags that are invalid for native documentation builds.
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .arg("doc")
+        .arg("--no-deps")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--target-dir")
+        .arg(&output_dir);
+    utils::run_command(command)?;
+
+    let documentation = output_dir
+        .join("doc")
+        .join(homework.slug)
+        .join("index.html");
+    utils::require_nonempty_file(&documentation)?;
+
+    let archive = output_dir.join(format!("{}.zip", homework.slug));
+    create_zip(&source, &archive, homework.slug).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "failed to create homework archive {}: {error}",
+                archive.display()
+            ),
+        )
+    })?;
+    utils::require_nonempty_file(&archive)
+}
+
+fn create_zip(source: &Path, output: &Path, root_name: &str) -> io::Result<()> {
+    let file = File::create(output)?;
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    for source_file in utils::files_in_tree(source)? {
+        let relative_path = source_file
+            .strip_prefix(source)
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        let archive_path = Path::new(root_name).join(relative_path);
+        let archive_path = archive_path.to_string_lossy().replace('\\', "/");
+
+        zip.start_file(archive_path, options)?;
+        io::copy(&mut File::open(source_file)?, &mut zip)?;
+    }
+
+    zip.finish()?;
+    Ok(())
+}

--- a/build/homeworks.rs
+++ b/build/homeworks.rs
@@ -37,9 +37,11 @@ pub fn build(manifest_dir: &Path) -> io::Result<()> {
 fn build_homework(homework: &Homework, manifest_dir: &Path) -> io::Result<()> {
     let source = manifest_dir.join(homework.source);
     let output_dir = manifest_dir.join("public/hw").join(homework.slug);
+    let target_dir = manifest_dir
+        .join("target/homework-docs")
+        .join(homework.slug);
 
     utils::require_directory(&source)?;
-    utils::create_directory(&output_dir)?;
 
     let manifest = source.join("Cargo.toml");
     let mut command = Command::new("cargo");
@@ -51,14 +53,17 @@ fn build_homework(homework: &Homework, manifest_dir: &Path) -> io::Result<()> {
         .arg("--manifest-path")
         .arg(&manifest)
         .arg("--target-dir")
-        .arg(&output_dir);
+        .arg(&target_dir);
     utils::run_command(command)?;
 
-    let documentation = output_dir
+    let generated_documentation = target_dir
         .join("doc")
         .join(homework.slug)
         .join("index.html");
-    utils::require_nonempty_file(&documentation)?;
+    utils::require_nonempty_file(&generated_documentation)?;
+
+    utils::recreate_directory(&output_dir)?;
+    utils::copy_directory(&target_dir.join("doc"), &output_dir.join("doc"))?;
 
     let archive = output_dir.join(format!("{}.zip", homework.slug));
     create_zip(&source, &archive, homework.slug).map_err(|error| {

--- a/build/lectures.rs
+++ b/build/lectures.rs
@@ -1,0 +1,162 @@
+use crate::utils;
+use rayon::prelude::*;
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+struct Lecture {
+    directory: &'static str,
+    slug: &'static str,
+}
+
+impl Lecture {
+    const fn new(directory: &'static str, slug: &'static str) -> Self {
+        Self { directory, slug }
+    }
+}
+
+const LECTURES: &[Lecture] = &[
+    Lecture::new("01_introduction", "introduction"),
+    Lecture::new("02_ownership_p1", "ownership_p1"),
+    Lecture::new("03_structs_enums", "structs_enums"),
+    Lecture::new("04_collections_generics", "collections_generics"),
+    Lecture::new("05_errors_traits", "errors_traits"),
+    Lecture::new("06_modules_testing", "modules_testing"),
+    Lecture::new("07_ecosystem", "ecosystem"),
+    Lecture::new("08_closures_iterators", "closures_iterators"),
+    Lecture::new("09_ownership_p2", "ownership_p2"),
+    Lecture::new("10_lifetimes", "lifetimes"),
+    Lecture::new("11_smart_pointers", "smart_pointers"),
+    Lecture::new("12_unsafe", "unsafe"),
+    Lecture::new("13_parallelism", "parallelism"),
+    Lecture::new("14_concurrency", "concurrency"),
+];
+
+pub fn build(manifest_dir: &Path) -> io::Result<()> {
+    let source_root = manifest_dir.join("lectures");
+    let output_root = manifest_dir.join("public/lectures");
+    let config = source_root.join("marp_config.json");
+    let theme = source_root.join("styles/rust.css");
+
+    utils::require_nonempty_file(&config)?;
+    utils::require_nonempty_file(&theme)?;
+
+    let mut shared_inputs = vec![config.clone(), theme];
+    for directory in ["fonts", "images", "styles"] {
+        let path = source_root.join(directory);
+        if path.exists() {
+            shared_inputs.extend(utils::files_in_tree(&path)?);
+        }
+    }
+
+    LECTURES.par_iter().try_for_each(|lecture| {
+        build_lecture(lecture, &source_root, &output_root, &config, &shared_inputs)
+    })
+}
+
+fn build_lecture(
+    lecture: &Lecture,
+    source_root: &Path,
+    output_root: &Path,
+    config: &Path,
+    shared_inputs: &[PathBuf],
+) -> io::Result<()> {
+    let source_dir = source_root.join(lecture.directory);
+    let source = source_dir.join(format!("{}.md", lecture.slug));
+
+    let output_dir = output_root.join(lecture.directory);
+    let dark_pdf = output_dir.join(format!("{}-dark.pdf", lecture.slug));
+    let light_pdf = output_dir.join(format!("{}-light.pdf", lecture.slug));
+
+    utils::require_nonempty_file(&source)?;
+    utils::create_directory(&output_dir)?;
+
+    let mut dependencies = utils::files_in_tree(&source_dir)?;
+    dependencies.extend_from_slice(shared_inputs);
+
+    let generated_files = [dark_pdf.as_path(), light_pdf.as_path()];
+    if utils::generated_files_are_current(&dependencies, &generated_files) {
+        return Ok(());
+    }
+
+    render_marp(&source, &dark_pdf, config, &source_dir)?;
+    render_light_marp(&source, &light_pdf, config, &source_dir)?;
+
+    utils::require_nonempty_file(&dark_pdf)?;
+    utils::require_nonempty_file(&light_pdf)?;
+
+    println!("cargo:warning=Rendered {}", lecture.slug);
+    Ok(())
+}
+
+/// Renders a light-mode PDF by commenting out the dark-mode directive in a temporary source copy.
+fn render_light_marp(
+    input: &Path,
+    output: &Path,
+    config: &Path,
+    working_dir: &Path,
+) -> io::Result<()> {
+    let file_stem = input.file_stem().ok_or_else(|| {
+        io::Error::other(format!(
+            "lecture source {} has no file stem",
+            input.display()
+        ))
+    })?;
+    let temporary_source =
+        input.with_file_name(format!("{}-light-temp.md", file_stem.to_string_lossy()));
+
+    let markdown = fs::read_to_string(input).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("failed to read lecture source {}: {error}", input.display()),
+        )
+    })?;
+    fs::write(
+        &temporary_source,
+        markdown.replace("class: invert", "# class: invert"),
+    )
+    .map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "failed to write temporary lecture source {}: {error}",
+                temporary_source.display()
+            ),
+        )
+    })?;
+
+    // Always try to remove the temporary source, even when Marp fails.
+    let render_result = render_marp(&temporary_source, output, config, working_dir);
+    let cleanup_result = fs::remove_file(&temporary_source).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "failed to remove temporary lecture source {}: {error}",
+                temporary_source.display()
+            ),
+        )
+    });
+    render_result?;
+    cleanup_result
+}
+
+fn render_marp(input: &Path, output: &Path, config: &Path, working_dir: &Path) -> io::Result<()> {
+    let file_name = input.file_name().ok_or_else(|| {
+        io::Error::other(format!(
+            "lecture source {} has no file name",
+            input.display()
+        ))
+    })?;
+
+    let mut command = Command::new("marp");
+    command
+        .arg(file_name)
+        .arg("-c")
+        .arg(config)
+        .arg("-o")
+        .arg(output)
+        .current_dir(working_dir);
+    utils::run_command(command)
+}

--- a/build/utils.rs
+++ b/build/utils.rs
@@ -82,6 +82,35 @@ pub fn create_directory(path: &Path) -> io::Result<()> {
     })
 }
 
+/// Recreates a directory so it contains no stale files from earlier builds.
+pub fn recreate_directory(path: &Path) -> io::Result<()> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    create_directory(path)
+}
+
+/// Recursively copies a directory and its contents to a new location.
+pub fn copy_directory(source: &Path, destination: &Path) -> io::Result<()> {
+    create_directory(destination)?;
+
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let destination = destination.join(entry.file_name());
+
+        if entry.file_type()?.is_dir() {
+            copy_directory(&entry.path(), &destination)?;
+        } else {
+            fs::copy(entry.path(), destination)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Verifies that a required path exists and is a directory.
 pub fn require_directory(path: &Path) -> io::Result<()> {
     let metadata = fs::metadata(path).map_err(|error| {

--- a/build/utils.rs
+++ b/build/utils.rs
@@ -1,0 +1,121 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Returns every visible file beneath the directory that is not excluded by ignore rules.
+pub fn files_in_tree(root: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+
+    for entry in ignore::Walk::new(root) {
+        let entry = entry.map_err(|error| {
+            io::Error::other(format!("failed to inspect {}: {error}", root.display()))
+        })?;
+
+        if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+        {
+            files.push(entry.into_path());
+        }
+    }
+
+    Ok(files)
+}
+
+/// Returns whether every generated file is current, treating empty dependencies or unavailable
+/// metadata as stale.
+pub fn generated_files_are_current(dependencies: &[PathBuf], generated_files: &[&Path]) -> bool {
+    let newest_dependency = dependencies
+        .iter()
+        .map(|path| {
+            fs::metadata(path)
+                .and_then(|metadata| metadata.modified())
+                .ok()
+        })
+        .collect::<Option<Vec<_>>>()
+        .and_then(|timestamps| timestamps.into_iter().max());
+
+    let Some(newest_dependency) = newest_dependency else {
+        return false;
+    };
+
+    generated_files.iter().all(|file| {
+        let Ok(metadata) = fs::metadata(file) else {
+            return false;
+        };
+
+        metadata.is_file()
+            && metadata.len() > 0
+            && metadata
+                .modified()
+                .is_ok_and(|timestamp| timestamp >= newest_dependency)
+    })
+}
+
+/// Runs a command and returns an error if it cannot start or exits unsuccessfully.
+pub fn run_command(mut command: Command) -> io::Result<()> {
+    let invocation = format!("{command:?}");
+
+    // `.status()` runs the command.
+    let status = command.status().map_err(|error| {
+        io::Error::new(error.kind(), format!("failed to run {invocation}: {error}"))
+    })?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "{invocation} exited unsuccessfully: {status}"
+        )))
+    }
+}
+
+/// Creates a directory and any missing parent directories.
+pub fn create_directory(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("failed to create directory {}: {error}", path.display()),
+        )
+    })
+}
+
+/// Verifies that a required path exists and is a directory.
+pub fn require_directory(path: &Path) -> io::Result<()> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("required directory {} is missing: {error}", path.display()),
+        )
+    })?;
+
+    if metadata.is_dir() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "required directory {} is not a directory",
+            path.display()
+        )))
+    }
+}
+
+/// Verifies that a required path exists and is a non-empty file.
+pub fn require_nonempty_file(path: &Path) -> io::Result<()> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("required file {} is missing: {error}", path.display()),
+        )
+    })?;
+
+    if metadata.is_file() && metadata.len() > 0 {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "required file {} is not a non-empty file",
+            path.display()
+        )))
+    }
+}


### PR DESCRIPTION
Refactors build.rs into focused modules, improves documentation, and makes generator failures stop the build promptly.

Homework Rustdoc now builds under target/, and only the generated documentation and archives are copied into public/.