### PR TITLE
Deploy website with Cloudflare Workers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  deployments: write
 
 concurrency:
   group: website-${{ github.event.pull_request.number || github.ref }}
@@ -36,6 +35,18 @@ jobs:
   build:
     needs: validate
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event_name == 'pull_request' && format('preview-pr-{0}', github.event.pull_request.number) || 'production' }}
+      url: ${{ steps.preview.outputs.deployment-url || steps.production.outputs.deployment-url }}
+      deployment: >-
+        ${{
+          github.ref == 'refs/heads/main' ||
+          (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.actor != 'dependabot[bot]'
+          )
+        }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -96,6 +107,7 @@ jobs:
           path: target/dx/stuco-rs/release/web/public/syllabus.pdf
 
       - name: Deploy production website
+        id: production
         if: github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@v4
         with:
@@ -116,42 +128,3 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: "4"
           command: versions upload --preview-alias pr-${{ github.event.pull_request.number }}
-
-      - name: Record preview deployment
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]'
-        uses: actions/github-script@v8
-        env:
-          PREVIEW_URL: ${{ steps.preview.outputs.deployment-url }}
-        with:
-          script: |
-            const previewUrl = process.env.PREVIEW_URL;
-
-            if (!previewUrl) {
-              core.setFailed("Wrangler did not return a preview URL.");
-              return;
-            }
-
-            const { data: deployment } = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.sha,
-              environment: `preview-pr-${context.issue.number}`,
-              description: "Cloudflare preview",
-              transient_environment: true,
-              production_environment: false,
-              auto_merge: false,
-              required_contexts: [],
-            });
-
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: deployment.id,
-              state: "success",
-              environment_url: previewUrl,
-              description: "Cloudflare preview is ready.",
-              auto_inactive: true,
-            });

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,18 @@
-name: Deploy to GitHub Pages
+name: Deploy website
 
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: website-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -71,6 +75,7 @@ jobs:
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
+            !target/dx/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Dioxus CLI
@@ -80,27 +85,75 @@ jobs:
       - name: Build
         run: dx build --release
 
-      - name: Copy index.html to 404.html
-        run: cp target/dx/stuco-rs/release/web/public/index.html target/dx/stuco-rs/release/web/public/404.html
-
       - name: Upload syllabus artifact
         uses: actions/upload-artifact@v4
         with:
           name: syllabus
           path: target/dx/stuco-rs/release/web/public/syllabus.pdf
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Deploy production website
+        if: github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v4
         with:
-          path: target/dx/stuco-rs/release/web/public
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
+          command: deploy
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy preview website
+        id: preview
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
+          command: versions upload --preview-alias pr-${{ github.event.pull_request.number }}
+
+      - name: Add preview link to pull request
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.deployment-url }}
+        with:
+          script: |
+            const marker = "<!-- cloudflare-preview -->";
+            const previewUrl = process.env.PREVIEW_URL;
+
+            if (!previewUrl) {
+              core.setFailed("Wrangler did not return a preview URL.");
+              return;
+            }
+
+            const body = `${marker}\nCloudflare preview: ${previewUrl}`;
+            const issue = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            };
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              issue,
+            );
+            const previous = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.startsWith(marker),
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({ ...issue, body });
+            }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,13 @@ jobs:
 
       - name: Install Dioxus CLI
         uses: cargo-bins/cargo-binstall@main
-      - run: cargo binstall dioxus-cli --no-confirm
+
+      - name: Install Dioxus CLI 0.7.2
+        run: cargo binstall dioxus-cli@0.7.2 --no-confirm
 
       - name: Build
+        env:
+          RAYON_NUM_THREADS: 2
         run: dx build --release
 
       - name: Upload syllabus artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,17 @@ permissions:
 
 concurrency:
   group: website-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Taplo
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.79.11
         with:
           tool: taplo
           fallback: none
@@ -37,19 +37,26 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event_name == 'pull_request' && format('preview-pr-{0}', github.event.pull_request.number) || 'production' }}
-      url: ${{ steps.preview.outputs.deployment-url || steps.production.outputs.deployment-url }}
+      url: >-
+        ${{
+          github.event_name == 'pull_request' &&
+          format(
+            'https://pr-{0}-stuco-rs.rust-stuco.workers.dev',
+            github.event.pull_request.number
+          ) ||
+          steps.production.outputs.deployment-url
+        }}
       deployment: >-
         ${{
           github.ref == 'refs/heads/main' ||
           (
             github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.actor != 'dependabot[bot]'
+            github.event.pull_request.head.repo.full_name == github.repository
           )
         }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -90,13 +97,13 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Dioxus CLI
-        uses: cargo-bins/cargo-binstall@main
-
-      - name: Install Dioxus CLI 0.7.2
-        run: cargo binstall dioxus-cli@0.7.2 --no-confirm --force
+        uses: taiki-e/install-action@v2.79.11
+        with:
+          tool: dioxus-cli@0.7.2
 
       - name: Build
         env:
+          # Limit parallel rendering to avoid exhausting CI runner resources.
           RAYON_NUM_THREADS: 2
         run: dx build --release
 
@@ -120,8 +127,7 @@ jobs:
         id: preview
         if: >-
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]'
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Taplo
-        uses: taiki-e/install-action@v2.79.11
+        uses: taiki-e/install-action@v2
         with:
           tool: taplo
           fallback: none
@@ -97,7 +97,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Dioxus CLI
-        uses: taiki-e/install-action@v2.79.11
+        uses: taiki-e/install-action@v2
         with:
           tool: dioxus-cli@0.7.2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  deployments: write
 
 concurrency:
   group: website-${{ github.event.pull_request.number || github.ref }}
@@ -117,7 +117,7 @@ jobs:
           wranglerVersion: "4"
           command: versions upload --preview-alias pr-${{ github.event.pull_request.number }}
 
-      - name: Add preview link to pull request
+      - name: Record preview deployment
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
@@ -127,7 +127,6 @@ jobs:
           PREVIEW_URL: ${{ steps.preview.outputs.deployment-url }}
         with:
           script: |
-            const marker = "<!-- cloudflare-preview -->";
             const previewUrl = process.env.PREVIEW_URL;
 
             if (!previewUrl) {
@@ -135,29 +134,24 @@ jobs:
               return;
             }
 
-            const body = `${marker}\nCloudflare preview: ${previewUrl}`;
-            const issue = {
+            const { data: deployment } = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-            };
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              issue,
-            );
-            const previous = comments.find(
-              (comment) =>
-                comment.user?.login === "github-actions[bot]" &&
-                comment.body?.startsWith(marker),
-            );
+              ref: context.sha,
+              environment: `preview-pr-${context.issue.number}`,
+              description: "Cloudflare preview",
+              transient_environment: true,
+              production_environment: false,
+              auto_merge: false,
+              required_contexts: [],
+            });
 
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({ ...issue, body });
-            }
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: "success",
+              environment_url: previewUrl,
+              description: "Cloudflare preview is ready.",
+              auto_inactive: true,
+            });

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install Dioxus CLI 0.7.2
-        run: cargo binstall dioxus-cli@0.7.2 --no-confirm
+        run: cargo binstall dioxus-cli@0.7.2 --no-confirm --force
 
       - name: Build
         env:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "name": "stuco-rs",
+  "compatibility_date": "2026-07-18",
+  "workers_dev": true,
+  "preview_urls": true,
+  "assets": {
+    "directory": "./target/dx/stuco-rs/release/web/public",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
Replaces the GitHub Pages deployment with Cloudflare Workers Static Assets. Deployments from `main` update production, while same-repository pull requests receive stable preview URLs and an automatically updated link.

Configures SPA fallback routing and keeps Dioxus deployment output out of the Cargo cache so stale generated files are not published.
