### PR TITLE
Cleanups (cloudflare and docs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,19 +8,29 @@ This project uses the `typst` CLI to compile the [syllabus source file](src/syll
 
 Download and install `typst` from the [official website](https://typst.app/open-source/#download)!
 
-### Website
+### Lecture slides
 
-You need to install `dioxus-cli` to build and run the website:
+The build renders every lecture deck to PDF with the `marp` CLI, so you need it installed even if you
+are only working on the website:
 
 ```bash
-cargo install dioxus-cli
+npm install -g @marp-team/marp-cli
+```
+
+### Website
+
+You need to install `dioxus-cli` to build and run the website. Pin the same version CI uses, since a
+mismatch can fail to build the crate:
+
+```bash
+cargo install dioxus-cli --version 0.7.2
 ```
 
 Alternatively, you can use `cargo binstall` to install a pre-built binary (faster):
 
 ```bash
 cargo install cargo-binstall
-cargo binstall dioxus-cli
+cargo binstall dioxus-cli@0.7.2
 ```
 
 ## Development

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,14 @@
 {
+  // Served at https://stuco.rs, attached to this Worker as a Cloudflare custom domain. `www`
+  // redirects to the apex through a zone redirect rule. Both live in Cloudflare rather than here,
+  // because a `routes` entry would make every deploy reassert the binding and need a broader API
+  // token than deploying assets does.
   "name": "stuco-rs",
   "compatibility_date": "2026-07-18",
-  "workers_dev": true,
+  // Off so `stuco-rs.rust-stuco.workers.dev` stops serving a public duplicate of the site. Preview
+  // URLs default to this setting, so `preview_urls` below keeps the `pr-<number>` aliases that the
+  // deploy workflow uploads.
+  "workers_dev": false,
   "preview_urls": true,
   "assets": {
     "directory": "./target/dx/stuco-rs/release/web/public",


### PR DESCRIPTION
2 commits, updates the `CONTRIBUTING` file to lock the dixous version since I ran into that locally, and then set `workers_dev` to false to remove the extra public surface.